### PR TITLE
New stateful telnet base class that react to keys

### DIFF
--- a/fake_switches/telnet/__init__.py
+++ b/fake_switches/telnet/__init__.py
@@ -1,0 +1,18 @@
+# Copyright 2015 Internap.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import re
+
+
+def lf_to_crlf(text):
+    return re.sub("(^|[^\r])\n", "\\1\r\n", text)

--- a/tests/util/protocol_util.py
+++ b/tests/util/protocol_util.py
@@ -114,7 +114,4 @@ class TelnetTester(ProtocolTester):
         self.write(self.username)
         self.read("Password: ")
         self.write_invisible(self.password)
-        self.read("my_switch[>#]", regex=True)
-
-    def write_invisible(self, data):
-        self.child.sendline(data)
+        self.wait_for('[>#]$', regex=True)


### PR DESCRIPTION
It was impossible (or very hard) to make the StatefulTelnetProtocol react to a single character and that was needed for the upcoming fake DELL support.
The new class implements Telnet directly and handles data on a key basis, stating that the server will echo character (self.will(ECHO)) and will not wait for an "enter" (or "go-ahead") to act by supressing go-ahead (self.will(SGA))

Inheritors of the class can change the self.handler to change the state