### PR TITLE
Add spanning-tree and lldp support on Dell

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@ ChangeLog
 .tox
 *.pyc
 *.coverage
+*.egg/
 *.egg-info
 .eggs/
 .venv
+dist/

--- a/fake_switches/dell/command_processor/config_interface.py
+++ b/fake_switches/dell/command_processor/config_interface.py
@@ -50,6 +50,39 @@ class DellConfigInterfaceCommandProcessor(ConfigInterfaceCommandProcessor):
         super(DellConfigInterfaceCommandProcessor, self).do_shutdown(*_)
         self.write_line("")
 
+    def do_spanning_tree(self, *args):
+        if "disable".startswith(args[0]):
+            self.port.spanning_tree = False
+        if "portfast".startswith(args[0]):
+            self.port.spanning_tree_portfast = True
+        self.write_line("")
+
+    def do_no_spanning_tree(self, *args):
+        if "disable".startswith(args[0]):
+            self.port.spanning_tree = None
+        if "portfast".startswith(args[0]):
+            self.port.spanning_tree_portfast = None
+        self.write_line("")
+
+    def do_lldp(self, *args):
+        self.configure_lldp_port(args, target_value=True)
+        self.write_line("")
+
+    def do_no_lldp(self, *args):
+        self.configure_lldp_port(args, target_value=False)
+        self.write_line("")
+
+    def configure_lldp_port(self, args, target_value):
+        if "transmit".startswith(args[0]):
+            self.port.lldp_transmit = target_value
+        elif "receive".startswith(args[0]):
+            self.port.lldp_receive = target_value
+        elif "med".startswith(args[0]) and "transmit-tlv".startswith(args[1]):
+            if "capabilities".startswith(args[2]):
+                self.port.lldp_med_transmit_capabilities = target_value
+            elif "network-policy".startswith(args[2]):
+                self.port.lldp_med_transmit_network_policy = target_value
+
     def do_name(self, *args):
         if len(args) == 0:
             self.write_line("")

--- a/fake_switches/dell/command_processor/enabled.py
+++ b/fake_switches/dell/command_processor/enabled.py
@@ -113,6 +113,18 @@ class EnabledCommandProcessor(BaseCommandProcessor):
             conf.append('switchport general pvid {}'.format(port.trunk_native_vlan))
         if port.trunk_vlans:
             conf.append('switchport {} allowed vlan add {}'.format(port.mode, to_vlan_ranges(port.trunk_vlans)))
+        if port.spanning_tree is False:
+            conf.append("spanning-tree disable")
+        if port.spanning_tree_portfast:
+            conf.append("spanning-tree portfast")
+        if port.lldp_transmit is False:
+            conf.append('no lldp transmit')
+        if port.lldp_receive is False:
+            conf.append('no lldp receive')
+        if port.lldp_med_transmit_capabilities is False:
+            conf.append('no lldp med transmit-tlv capabilities')
+        if port.lldp_med_transmit_network_policy is False:
+            conf.append('no lldp med transmit-tlv network-policy')
 
         return conf
 

--- a/fake_switches/switch_configuration.py
+++ b/fake_switches/switch_configuration.py
@@ -113,6 +113,9 @@ class Port(object):
     def __init__(self, name):
         self.name = name
         self.switch_configuration = None
+        self.reset()
+
+    def reset(self):
         self.description = None
         self.mode = None
         self.access_vlan = None
@@ -126,19 +129,12 @@ class Port(object):
         self.aggregation_membership = None
         self.vendor_specific = {}
         self.ip_helpers = []
-
-    def reset(self):
-        self.description = None
-        self.mode = None
-        self.access_vlan = None
-        self.trunk_vlans = None
-        self.trunk_native_vlan = None
-        self.shutdown = None
-        self.vrf = None
-        self.speed = None
-        self.auto_negotiation = None
-        self.aggregation_membership = None
-        self.vendor_specific = {}
+        self.lldp_transmit = None
+        self.lldp_receive = None
+        self.lldp_med_transmit_capabilities = None
+        self.lldp_med_transmit_network_policy = None
+        self.spanning_tree = None
+        self.spanning_tree_portfast = None
 
     def get_subname(self, length):
         name, number = split_port_name(self.name)
@@ -174,7 +170,7 @@ class VlanPort(Port):
         self.vrrps = []
 
     def get_vrrp_group(self, group):
-        return next((vrrp for vrrp in self.vrrps if vrrp.group_id==group), None)
+        return next((vrrp for vrrp in self.vrrps if vrrp.group_id == group), None)
 
     def add_ip(self, ip_network):
         existing_ip = next((ip for ip in self.ips if ip.ip == ip_network.ip), None)

--- a/tests/dell/test_configure_interface.py
+++ b/tests/dell/test_configure_interface.py
@@ -98,6 +98,50 @@ class DellConfigureInterfaceTest(unittest.TestCase):
         ])
 
     @with_protocol
+    def test_lldp_options_defaults_to_enabled(self, t):
+        enable(t)
+        configuring_interface(t, "ethernet 1/g1", do='no lldp transmit')
+        configuring_interface(t, "ethernet 1/g1", do='no lldp receive')
+        configuring_interface(t, "ethernet 1/g1", do='no lldp med transmit-tlv capabilities')
+        configuring_interface(t, "ethernet 1/g1", do='no lldp med transmit-tlv network-policy')
+
+        assert_interface_configuration(t, "ethernet 1/g1", [
+            'no lldp transmit',
+            'no lldp receive',
+            'no lldp med transmit-tlv capabilities',
+            'no lldp med transmit-tlv network-policy',
+        ])
+
+        configuring_interface(t, "ethernet 1/g1", do='lldp transmit')
+        configuring_interface(t, "ethernet 1/g1", do='lldp receive')
+        configuring_interface(t, "ethernet 1/g1", do='lldp med transmit-tlv capabilities')
+        configuring_interface(t, "ethernet 1/g1", do='lldp med transmit-tlv network-policy')
+
+        assert_interface_configuration(t, "ethernet 1/g1", [
+            '',
+        ])
+
+    @with_protocol
+    def test_spanning_tree(self, t):
+        enable(t)
+        configuring_interface(t, "ethernet 1/g1", do='spanning-tree disable')
+        configuring_interface(t, "ethernet 1/g1", do='spanning-tree portfast')
+
+        assert_interface_configuration(t, "ethernet 1/g1", [
+            'spanning-tree disable',
+            'spanning-tree portfast',
+        ])
+
+        configuring_interface(t, "ethernet 1/g1", do='no spanning-tree disable')
+        configuring_interface(t, "ethernet 1/g1", do='no spanning-tree portfast')
+
+        assert_interface_configuration(t, "ethernet 1/g1", [
+            ''
+        ])
+
+
+
+    @with_protocol
     def test_access_vlan_that_doesnt_exist_prints_a_warning_and_config_is_unchanged(self, t):
         enable(t)
         configure(t)


### PR DESCRIPTION
2 new spanning-tree interface commands:
  - spanning-tree disable
  - spanning-tree portfast

4 new lldp interface commands:
  - lldp transmit
  - lldp receive
  - lldp med transmit-tlv capabilities
  - lldp med transmit-tlv network-policy