### PR TITLE
Support show etherchannel summary on cisco.

### DIFF
--- a/tests/cisco/test_cisco_auto_enabled_switch.py
+++ b/tests/cisco/test_cisco_auto_enabled_switch.py
@@ -30,7 +30,7 @@ class TestCiscoAutoEnabledSwitchProtocol(unittest.TestCase):
         t.read("my_switch#")
 
     def create_client(self):
-        raise NotImplemented()
+        raise NotImplementedError()
 
 
 class TestCiscoSwitchProtocolSSH(TestCiscoAutoEnabledSwitchProtocol):

--- a/tests/cisco/test_cisco_switch_protocol.py
+++ b/tests/cisco/test_cisco_switch_protocol.py
@@ -452,6 +452,28 @@ class TestCiscoSwitchProtocol(unittest.TestCase):
             "end"
         ])
 
+        t.write("show etherchannel summary")
+        t.readln("Flags:  D - down        P - bundled in port-channel")
+        t.readln("        I - stand-alone s - suspended")
+        t.readln("        H - Hot-standby (LACP only)")
+        t.readln("        R - Layer3      S - Layer2")
+        t.readln("        U - in use      f - failed to allocate aggregator")
+        t.readln("")
+        t.readln("        M - not in use, minimum links not met")
+        t.readln("        u - unsuitable for bundling")
+        t.readln("        w - waiting to be aggregated")
+        t.readln("        d - default port")
+        t.readln("")
+        t.readln("")
+        t.readln("Number of channel-groups in use: 1")
+        t.readln("Number of aggregators:           1")
+        t.readln("")
+        t.readln("Group  Port-channel  Protocol    Ports")
+        t.readln("------+-------------+-----------+-----------------------------------------------")
+        t.readln("1      Po1(S)          LACP      ")
+        t.readln("")
+        t.read("my_switch#")
+
         configuring(t, do="no interface port-channel 1")
 
         t.write("show run int po1")
@@ -487,6 +509,28 @@ class TestCiscoSwitchProtocol(unittest.TestCase):
             "interface Port-channel2",
             "end"
         ])
+
+        t.write("show etherchannel summary")
+        t.readln("Flags:  D - down        P - bundled in port-channel")
+        t.readln("        I - stand-alone s - suspended")
+        t.readln("        H - Hot-standby (LACP only)")
+        t.readln("        R - Layer3      S - Layer2")
+        t.readln("        U - in use      f - failed to allocate aggregator")
+        t.readln("")
+        t.readln("        M - not in use, minimum links not met")
+        t.readln("        u - unsuitable for bundling")
+        t.readln("        w - waiting to be aggregated")
+        t.readln("        d - default port")
+        t.readln("")
+        t.readln("")
+        t.readln("Number of channel-groups in use: 1")
+        t.readln("Number of aggregators:           1")
+        t.readln("")
+        t.readln("Group  Port-channel  Protocol    Ports")
+        t.readln("------+-------------+-----------+-----------------------------------------------")
+        t.readln("2      Po2(SU)         LACP      Fa0/1(P)")
+        t.readln("")
+        t.read("my_switch#")
 
         configuring(t, do="no interface port-channel 2")
 


### PR DESCRIPTION
Returns the list of port channels and members as follow:

```
cisco.switch#show etherchannel summary 
Flags:  D - down        P - bundled in port-channel
        I - stand-alone s - suspended
        H - Hot-standby (LACP only)
        R - Layer3      S - Layer2
        U - in use      f - failed to allocate aggregator

        M - not in use, minimum links not met
        u - unsuitable for bundling
        w - waiting to be aggregated
        d - default port


Number of channel-groups in use: 1
Number of aggregators:           1

Group  Port-channel  Protocol    Ports
------+-------------+-----------+-----------------------------------------------
1      Po1(SU)         LACP      Gi1/0/1(P)  Gi1/0/2(P)  

cisco.switch#
```