### PR TITLE
Fix display of interface channel-group on cisco.

### DIFF
--- a/fake_switches/cisco/command_processor/enabled.py
+++ b/fake_switches/cisco/command_processor/enabled.py
@@ -246,7 +246,7 @@ def build_running_interface(port):
     if port.shutdown:
         data.append(" shutdown")
     if port.aggregation_membership:
-        data.append(" channel-group %s mode active" % port.aggregation_membership[-1])
+        data.append(" channel-group %s mode active" % last_number(port.aggregation_membership))
     if port.vrf:
         data.append(" ip vrf forwarding %s" % port.vrf.name)
     if isinstance(port, VlanPort):
@@ -306,7 +306,11 @@ def to_range_string(array_range):
 
 
 def port_channel_number(port):
-    return int(re.match(r'(.*?)(\d+$)', port.name).groups()[1])
+    return last_number(port.name)
+
+
+def last_number(text):
+    return int(re.match(r'(.*?)(\d+$)', text).groups()[1])
 
 
 def short_name(port):

--- a/tests/cisco/test_cisco_switch_protocol.py
+++ b/tests/cisco/test_cisco_switch_protocol.py
@@ -545,14 +545,14 @@ class TestCiscoSwitchProtocol(unittest.TestCase):
     def test_port_channel_is_not_automatically_created_when_adding_a_port_to_it_if_its_already_created(self, t):
         enable(t)
 
-        create_port_channel_interface(t, '4')
+        create_port_channel_interface(t, '14')
 
         t.write("configure terminal")
         t.readln("Enter configuration commands, one per line.  End with CNTL/Z.")
         t.read("my_switch(config)#")
         t.write("interface FastEthernet0/1")
         t.read("my_switch(config-if)#")
-        t.write("channel-group 4 mode active")
+        t.write("channel-group 14 mode active")
         t.read("my_switch(config-if)#")
         t.write("exit")
         t.read("my_switch(config)#")
@@ -561,18 +561,18 @@ class TestCiscoSwitchProtocol(unittest.TestCase):
 
         assert_interface_configuration(t, "fa0/1", [
             "interface FastEthernet0/1",
-            " channel-group 4 mode active",
+            " channel-group 14 mode active",
             "end"
         ])
 
-        configuring_interface(t, interface="fa0/1", do="no channel-group 4 mode on")
+        configuring_interface(t, interface="fa0/1", do="no channel-group 14 mode on")
 
         assert_interface_configuration(t, "fa0/1", [
             "interface FastEthernet0/1",
             "end"
         ])
 
-        configuring(t, do="no interface port-channel 4")
+        configuring(t, do="no interface port-channel 14")
 
     @with_protocol
     def test_setting_secondary_ips(self, t):


### PR DESCRIPTION
Only the last digit of the channel-group number was displayed, now the number is entirely displayed.

Before:
```
interface Port-channel20
end

interface GigabitEthernet 1/0/1
  channel-group 0 mode active
end
```
After:
```
interface Port-channel20
end

interface GigabitEthernet 1/0/1
  channel-group 20 mode active
end
```
